### PR TITLE
Handle sets containing dictionaries

### DIFF
--- a/clj.py
+++ b/clj.py
@@ -269,7 +269,10 @@ class CljDecoder(object):
                     current_scope.append(v)
 
                 if container == "set":
-                    v = set(current_scope)
+                    try:
+                        v = set(current_scope)
+                    except TypeError:
+                        v = tuple(current_scope)
                 elif container == "list":
                     v = current_scope
                 elif container == "dict":

--- a/tests/clj-test.py
+++ b/tests/clj-test.py
@@ -34,6 +34,7 @@ class CljLoadTest(unittest.TestCase):
                      '#uuid "6eabd442-6958-484b-825d-aa79c0ad4967"': uuid.UUID("6eabd442-6958-484b-825d-aa79c0ad4967"),
                      '{:a #inst "2012-10-19T22:19:03.000-00:00"}': {"a":datetime(2012, 10, 19, 22, 19, 3, tzinfo=pytz.utc)},
                      '[#inst "2012-10-19T22:19:03.000-00:00"]': [datetime(2012, 10, 19, 22, 19, 3, tzinfo=pytz.utc)]
+                     '{:likes #{{:db/id 2} {:db/id 1}}}': {'likes': tuple([{'db/id': 2}, {'db/id': 1}])}
                      }
 
     def test_all_data(self):


### PR DESCRIPTION
clj.py:268: TypeError: unhashable type: 'dict'

hack: catch the error and use a tuple() instead of set().
