### PR TITLE
employing json encoder to handle unicode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 dist/
 pyclj.egg-info/
+build/

--- a/tests/clj-test.py
+++ b/tests/clj-test.py
@@ -12,6 +12,8 @@ class CljLoadTest(unittest.TestCase):
                      "23": 23,
                      '23.45M': decimal.Decimal('23.45'),
                      "23.11": 23.11,
+                     "3141e5": 3141e5,
+                     "3.1415e7": 3.1415e7,
                      "true": True,
                      "false": False,
                      "nil": None,
@@ -20,7 +22,8 @@ class CljLoadTest(unittest.TestCase):
                      '"string\n"': 'string\n',
                      '[:hello]':["hello"],
                      '-10.4':-10.4,
-                     '"你"': '你',
+                     '{"a" "\\"A substring\\""}': {"a": "\"A substring\""},
+                     '"\\u4f60"': u'\u4f60',
                      "[1 2]": [1,2],
                      "#{true \"hello\" 12}": set([True, "hello", 12]),
                      "(\\a \\b \\c \\d)": ["a","b","c","d"],
@@ -33,7 +36,7 @@ class CljLoadTest(unittest.TestCase):
                      "#inst \"2012-10-19T22:19:03.000-00:00\"": datetime(2012, 10, 19, 22, 19, 3, tzinfo=pytz.utc),
                      '#uuid "6eabd442-6958-484b-825d-aa79c0ad4967"': uuid.UUID("6eabd442-6958-484b-825d-aa79c0ad4967"),
                      '{:a #inst "2012-10-19T22:19:03.000-00:00"}': {"a":datetime(2012, 10, 19, 22, 19, 3, tzinfo=pytz.utc)},
-                     '[#inst "2012-10-19T22:19:03.000-00:00"]': [datetime(2012, 10, 19, 22, 19, 3, tzinfo=pytz.utc)]
+                     '[#inst "2012-10-19T22:19:03.000-00:00"]': [datetime(2012, 10, 19, 22, 19, 3, tzinfo=pytz.utc)],
                      '{:likes #{{:db/id 2} {:db/id 1}}}': {'likes': tuple([{'db/id': 2}, {'db/id': 1}])}
                      }
 
@@ -54,6 +57,7 @@ class CljDumpTest(unittest.TestCase):
         self.data = {'"helloworld"': "helloworld",
                      '"hello\\"world"': "hello\"world",
                      '12': 12,
+                     '1000000.0': 1e6,
                      '23.45M': decimal.Decimal('23.45'),
                      '12.334': 12.334,
                      'true': True,
@@ -63,7 +67,11 @@ class CljDumpTest(unittest.TestCase):
                      "[1 2 3 4]": (1,2,3,4),
                      "[]": (),
                      "{}": {},
+                     '{"a" "\\"A substring \\u4f60\\""}': {"a": u"\"A substring \u4f60\""},
+                     '"\\u4f60"': u'\u4f60',
                      '{"a" 1 "b" 2}':{"a":1, "b":2},
+                     '{"\\u4f60" 1 "b" 2}':{u"\u4f60":1, "b":2},
+                     '["\\u4f60" "a" "b"]': [u"\u4f60", u"a", u"b"],
                      '#{1}': set([1]),
                      '["h" nil [1 2 3] {"w" true}]':["h",None,[1,2,3],{"w":True}],
                      '#inst "2012-10-19T14:16:54Z"':datetime(2012,10,19,14,16,54,907),


### PR DESCRIPTION
An attempt to add unicode support following https://github.com/edn-format/edn#general-considerations.  I found that the usual encode, decode routines don't uniformly encode the characters, mixing the \x and \u representations.  That is why I chose to use the json enconder module which converts both to \u.  Also updating tests and allowing more flexible number parsing.
